### PR TITLE
feat: add the ability to see who voted for suggestions

### DIFF
--- a/suggestions/bot.py
+++ b/suggestions/bot.py
@@ -199,6 +199,12 @@ class SuggestionsBot(commands.AutoShardedInteractionBot, BotBase):
             interaction.author.id, interaction.guild_id, stat_type, was_success=False
         )
 
+    async def on_user_command_error(self, interaction, exception) -> None:
+        return await self.on_slash_command_error(interaction, exception)
+
+    async def on_message_command_error(self, interaction, exception) -> None:
+        return await self.on_slash_command_error(interaction, exception)
+
     async def on_slash_command_error(
         self,
         interaction: disnake.ApplicationCommandInteraction,
@@ -280,7 +286,7 @@ class SuggestionsBot(commands.AutoShardedInteractionBot, BotBase):
             return await interaction.send(
                 embed=self.error_embed(
                     "Command failed",
-                    "No suggestion exists with this id.",
+                    str(exception),
                     error_code=ErrorCode.SUGGESTION_NOT_FOUND,
                 ),
                 ephemeral=True,

--- a/suggestions/clunk/clunk.py
+++ b/suggestions/clunk/clunk.py
@@ -19,7 +19,6 @@ class Clunk:
         try:
             return self._cache.get_entry(key)
         except NonExistentEntry:
-            log.debug("Acquired new ClunkLock for (%s)", suggestion_id)
             lock = ClunkLock(self._state)
             self._cache.add_entry(key, lock)
             return lock

--- a/suggestions/cogs/view_voters_cog.py
+++ b/suggestions/cogs/view_voters_cog.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import cooldowns
+import disnake
+from disnake.ext import commands
+from bot_base.paginators.disnake_paginator import DisnakePaginator
+
+from suggestions import Stats
+from suggestions.cooldown_bucket import InteractionBucket
+from suggestions.objects import Suggestion
+
+if TYPE_CHECKING:
+    from alaric import Document
+    from suggestions import SuggestionsBot, State
+
+log = logging.getLogger(__name__)
+
+
+class VoterPaginator(DisnakePaginator):
+    def __init__(self, data, suggestion_id: str, title_prefix: str):
+        self.title_prefix: str = title_prefix.lstrip()
+        self.suggestion_id: str = suggestion_id
+        super().__init__(
+            items_per_page=15, delete_buttons_on_stop=True, input_data=data
+        )
+
+    async def format_page(self, page_items: list, page_number: int) -> disnake.Embed:
+        embed = disnake.Embed(
+            title=f"{self.title_prefix} for suggestion `{self.suggestion_id}`",
+            description="\n".join(page_items),
+        )
+        embed.set_footer(text=f"Page {page_number} of {self.total_pages}")
+        return embed
+
+
+# noinspection DuplicatedCode
+class ViewVotersCog(commands.Cog):
+    """This cog allows users to view who has voted on a given suggestion."""
+
+    def __init__(self, bot: SuggestionsBot):
+        self.bot: SuggestionsBot = bot
+        self.state: State = self.bot.state
+        self.stats: Stats = self.bot.stats
+        self.suggestions_db: Document = self.bot.db.suggestions
+
+    @staticmethod
+    async def display_data(
+        interaction: disnake.GuildCommandInteraction,
+        *,
+        data,
+        suggestion: Suggestion,
+        title_prefix: str,
+    ):
+        """Display the paginated data to an end user."""
+        if not suggestion.uses_views_for_votes:
+            return await interaction.send(
+                "Suggestions using reactions are not supported by this command.",
+                ephemeral=True,
+            )
+
+        if not data:
+            return await interaction.send(
+                "There are no voters to show you for this.",
+                ephemeral=True,
+            )
+
+        vp: VoterPaginator = VoterPaginator(
+            data, suggestion.suggestion_id, title_prefix=title_prefix
+        )
+        await vp.start(interaction=interaction)
+
+    @commands.message_command(name="View voters")
+    @cooldowns.cooldown(1, 3, bucket=InteractionBucket.author)
+    async def view_suggestion_voters(
+        self, interaction: disnake.GuildCommandInteraction
+    ):
+        """View everyone who voted on this suggestion."""
+        await interaction.response.defer(ephemeral=True, with_message=True)
+        suggestion: Suggestion = await Suggestion.from_message_id(
+            message_id=interaction.target.id,
+            channel_id=interaction.channel_id,
+            state=self.state,
+        )
+        data = []
+        for voter in suggestion.up_voted_by:
+            data.append(f"<@{voter}> - Up vote")
+        for voter in suggestion.down_voted_by:
+            data.append(f"<@{voter}> - Down vote")
+
+        await self.display_data(
+            interaction,
+            data=data,
+            suggestion=suggestion,
+            title_prefix="Voters",
+        )
+
+    @commands.message_command(name="View up voters")
+    @cooldowns.cooldown(1, 3, bucket=InteractionBucket.author)
+    async def view_suggestion_up_voters(
+        self, interaction: disnake.GuildCommandInteraction
+    ):
+        """View everyone who up voted on this suggestion."""
+        await interaction.response.defer(ephemeral=True, with_message=True)
+        suggestion: Suggestion = await Suggestion.from_message_id(
+            message_id=interaction.target.id,
+            channel_id=interaction.channel_id,
+            state=self.state,
+        )
+        data = []
+        for voter in suggestion.up_voted_by:
+            data.append(f"<@{voter}>")
+
+        await self.display_data(
+            interaction,
+            data=data,
+            suggestion=suggestion,
+            title_prefix="Up voters",
+        )
+
+    @commands.message_command(name="View down voters")
+    @cooldowns.cooldown(1, 3, bucket=InteractionBucket.author)
+    async def view_suggestion_down_voters(
+        self, interaction: disnake.GuildCommandInteraction
+    ):
+        """View everyone who down voted on this suggestion."""
+        await interaction.response.defer(ephemeral=True, with_message=True)
+        suggestion: Suggestion = await Suggestion.from_message_id(
+            message_id=interaction.target.id,
+            channel_id=interaction.channel_id,
+            state=self.state,
+        )
+        data = []
+        for voter in suggestion.down_voted_by:
+            data.append(f"<@{voter}>")
+
+        await self.display_data(
+            interaction,
+            data=data,
+            suggestion=suggestion,
+            title_prefix="Down voters",
+        )
+
+
+def setup(bot):
+    bot.add_cog(ViewVotersCog(bot))

--- a/suggestions/cogs/view_voters_cog.py
+++ b/suggestions/cogs/view_voters_cog.py
@@ -26,7 +26,11 @@ class VoterPaginator(DisnakePaginator):
         suggestion_id: str,
         title_prefix: str,
         colors: Type[Colors],
+        bot: SuggestionsBot,
+        locale: disnake.Locale,
     ):
+        self.bot: SuggestionsBot = bot
+        self.locale: disnake.Locale = locale
         self.colors: Type[Colors] = colors
         self.title_prefix: str = title_prefix.lstrip()
         self.suggestion_id: str = suggestion_id
@@ -36,11 +40,17 @@ class VoterPaginator(DisnakePaginator):
 
     async def format_page(self, page_items: list, page_number: int) -> disnake.Embed:
         embed = disnake.Embed(
-            title=f"{self.title_prefix} for suggestion `{self.suggestion_id}`",
+            title=self.bot.get_locale(
+                "VOTER_PAGINATOR_INNER_EMBED_TITLE", self.locale
+            ).format(self.title_prefix, self.suggestion_id),
             description="\n".join(page_items),
             colour=self.colors.embed_color,
         )
-        embed.set_footer(text=f"Page {page_number} of {self.total_pages}")
+        embed.set_footer(
+            text=self.bot.get_locale(
+                "VOTER_PAGINATOR_INNER_EMBED_FOOTER", self.locale
+            ).format(page_number, self.total_pages)
+        )
         return embed
 
 
@@ -64,13 +74,15 @@ class ViewVotersCog(commands.Cog):
         """Display the paginated data to an end user."""
         if not suggestion.uses_views_for_votes:
             return await interaction.send(
-                "Suggestions using reactions are not supported by this command.",
+                self.bot.get_locale(
+                    "DISPLAY_DATA_INNER_OLD_SUGGESTION_TYPE", interaction.locale
+                ),
                 ephemeral=True,
             )
 
         if not data:
             return await interaction.send(
-                "There are no voters to show you for this.",
+                self.bot.get_locale("DISPLAY_DATA_INNER_NO_VOTERS", interaction.locale),
                 ephemeral=True,
             )
 
@@ -79,6 +91,8 @@ class ViewVotersCog(commands.Cog):
             suggestion.suggestion_id,
             title_prefix=title_prefix,
             colors=self.bot.colors,
+            bot=self.bot,
+            locale=interaction.locale,
         )
         await vp.start(interaction=interaction)
 
@@ -108,7 +122,9 @@ class ViewVotersCog(commands.Cog):
             interaction,
             data=data,
             suggestion=suggestion,
-            title_prefix="Voters",
+            title_prefix=self.bot.get_locale(
+                "VIEW_VOTERS_INNER_TITLE_PREFIX", interaction.locale
+            ),
         )
 
     @commands.message_command(name="View up voters")
@@ -131,7 +147,9 @@ class ViewVotersCog(commands.Cog):
             interaction,
             data=data,
             suggestion=suggestion,
-            title_prefix="Up voters",
+            title_prefix=self.bot.get_locale(
+                "VIEW_UP_VOTERS_INNER_TITLE_PREFIX", interaction.locale
+            ),
         )
 
     @commands.message_command(name="View down voters")
@@ -154,7 +172,9 @@ class ViewVotersCog(commands.Cog):
             interaction,
             data=data,
             suggestion=suggestion,
-            title_prefix="Down voters",
+            title_prefix=self.bot.get_locale(
+                "VIEW_DOWN_VOTERS_INNER_TITLE_PREFIX", interaction.locale
+            ),
         )
 
 

--- a/suggestions/cogs/view_voters_cog.py
+++ b/suggestions/cogs/view_voters_cog.py
@@ -94,11 +94,15 @@ class ViewVotersCog(commands.Cog):
             channel_id=interaction.channel_id,
             state=self.state,
         )
+
+        up_vote: disnake.Emoji = await self.bot.suggestion_emojis.default_up_vote()
+        down_vote: disnake.Emoji = await self.bot.suggestion_emojis.default_down_vote()
         data = []
         for voter in suggestion.up_voted_by:
-            data.append(f"<@{voter}> - Up vote")
+            data.append(f"{up_vote} <@{voter}>")
+        data.append("")
         for voter in suggestion.down_voted_by:
-            data.append(f"<@{voter}> - Down vote")
+            data.append(f"{down_vote} <@{voter}>")
 
         await self.display_data(
             interaction,

--- a/suggestions/cogs/view_voters_cog.py
+++ b/suggestions/cogs/view_voters_cog.py
@@ -43,7 +43,6 @@ class ViewVotersCog(commands.Cog):
     def __init__(self, bot: SuggestionsBot):
         self.bot: SuggestionsBot = bot
         self.state: State = self.bot.state
-        self.stats: Stats = self.bot.stats
         self.suggestions_db: Document = self.bot.db.suggestions
 
     @staticmethod

--- a/suggestions/emojis.py
+++ b/suggestions/emojis.py
@@ -22,8 +22,14 @@ class Emojis:
     def __init__(self, bot: SuggestionsBot):
         self.bot: SuggestionsBot = bot
 
+        if not self.bot.is_prod:
+            # Use the emojis from the test guild
+            self._tick = 756633653668479117
+            self._cross = 756633653286797443
+
     async def populate_emojis(self):
-        guild = await self.bot.fetch_guild(self.bot.main_guild_id)
+        guild_id = self.bot.main_guild_id if self.bot.is_prod else 737166408525283348
+        guild = await self.bot.fetch_guild(guild_id)
         self.tick = await guild.fetch_emoji(self._tick)
         self.cross = await guild.fetch_emoji(self._cross)
         log.info("Populated default emojis")

--- a/suggestions/locales/en_GB.json
+++ b/suggestions/locales/en_GB.json
@@ -36,5 +36,12 @@
   "SUGGESTION_DOWN_VOTE_INNER_NO_MORE_CASTING": "You can no longer cast votes on this suggestion.",
   "SUGGESTION_DOWN_VOTE_INNER_ALREADY_VOTED": "You have already down voted this suggestion.",
   "SUGGESTION_DOWN_VOTE_INNER_MODIFIED_VOTE": "I have changed your vote from an up vote to a down vote for this suggestion.",
-  "SUGGESTION_DOWN_VOTE_INNER_REGISTERED_VOTE": "Thanks!\nI have registered your down vote."
+  "SUGGESTION_DOWN_VOTE_INNER_REGISTERED_VOTE": "Thanks!\nI have registered your down vote.",
+  "VIEW_VOTERS_INNER_TITLE_PREFIX": "Voters",
+  "VIEW_UP_VOTERS_INNER_TITLE_PREFIX": "Up voters",
+  "VIEW_DOWN_VOTERS_INNER_TITLE_PREFIX": "Down voters",
+  "DISPLAY_DATA_INNER_OLD_SUGGESTION_TYPE": "Suggestions using reactions are not supported by this command.",
+  "DISPLAY_DATA_INNER_NO_VOTERS": "There are no voters to show you for this.",
+  "VOTER_PAGINATOR_INNER_EMBED_TITLE": "{} for suggestion `{}`",
+  "VOTER_PAGINATOR_INNER_EMBED_FOOTER": "Page {} of {}"
 }

--- a/suggestions/objects/suggestion.py
+++ b/suggestions/objects/suggestion.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Literal, Union, Optional
 import disnake
 from alaric import AQ
 from alaric.comparison import EQ
+from alaric.logical import AND
 from bot_base.wraps import WrappedChannel
 from disnake import Embed, Guild
 
@@ -195,6 +196,48 @@ class Suggestion:
             return Colors.approved_suggestion
 
         return Colors.pending_suggestion
+
+    @classmethod
+    async def from_message_id(
+        cls, message_id: int, channel_id: int, state: State
+    ) -> Suggestion:
+        """Return a suggestion from its sent message.
+
+        Useful for message commands.
+
+        Parameters
+        ----------
+        message_id : int
+            The message id
+        channel_id : int
+            The channel id
+        state : State
+            Our internal state
+
+        Returns
+        -------
+        Suggestion
+            The found suggestion
+
+        Raises
+        ------
+        SuggestionNotFound
+            No suggestion exists for this data
+        """
+        suggestion: Suggestion | None = await state.suggestions_db.find(
+            AQ(
+                AND(
+                    EQ("message_id", message_id),
+                    EQ("channel_id", channel_id),
+                )
+            )
+        )
+        if not suggestion:
+            raise SuggestionNotFound(
+                f"This message does not look like a suggestions message."
+            )
+
+        return suggestion
 
     @classmethod
     async def from_id(

--- a/suggestions/objects/suggestion.py
+++ b/suggestions/objects/suggestion.py
@@ -613,7 +613,7 @@ class Suggestion:
             await MessageEditing(
                 bot, channel_id=self.channel_id, message_id=self.message_id
             ).edit(embed=await self.as_embed(bot))
-        except disnake.HTTPException:
+        except (disnake.HTTPException, disnake.NotFound):
             await interaction.send(
                 embed=bot.error_embed(
                     "Command failed",

--- a/suggestions/objects/suggestion.py
+++ b/suggestions/objects/suggestion.py
@@ -608,7 +608,6 @@ class Suggestion:
         bot: SuggestionsBot,
         interaction: disnake.Interaction,
     ):
-        log.debug("Starting to update vote counts")
         try:
             await MessageEditing(
                 bot, channel_id=self.channel_id, message_id=self.message_id
@@ -623,5 +622,3 @@ class Suggestion:
                 ephemeral=True,
             )
             raise ErrorHandled
-
-        log.debug("Finished updating vote counts")

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -14,6 +14,7 @@ async def test_cogs_loaded(causar: Causar):
         "HelpGuildCog",
         "SuggestionsCog",
         "UserConfigCog",
+        "ViewVotersCog",
     ]
     assert len(bot.cogs) == len(cog_names)
     for cog_name in cog_names:


### PR DESCRIPTION
Partially resolves #15

This PR introduces the following 4 new responses: https://gyazo.com/00cfebf5330c462d4179392f8390b71e

- [X] Manual testing 
- [X] Handle both types of suggestions
- [X] Ratelimit the commands
- [ ] Write unit-tests
- [x] Add strings to locales files
- [x] Finalize sign off from Anthony for command names + UI look

This also improves the error given when ``SuggestionNotFound`` is raised as a side affect to be dynamically shown based on the raisee itself instead of hard-coded.