### PR TITLE
feat: add error persistence

### DIFF
--- a/suggestions/cogs/help_guild_cog.py
+++ b/suggestions/cogs/help_guild_cog.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import io
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import disnake
+from alaric import AQ
+from alaric.comparison import EQ
 from disnake.ext import commands
+from humanize import naturaldate
 
 from suggestions import ErrorCode
+from suggestions.objects import Error
 
 if TYPE_CHECKING:
     from suggestions import SuggestionsBot, State
@@ -78,6 +83,55 @@ class HelpGuildCog(commands.Cog):
             f"Guild `{guild_id}` should be in cluster `{cluster_id}` with the specific shard `{shard_id}`",
             ephemeral=True,
         )
+
+    @commands.slash_command(
+        dm_permission=False,
+        default_member_permissions=disnake.Permissions(kick_members=True),
+        guild_ids=[601219766258106399, 737166408525283348],
+    )
+    async def error_information(
+        self,
+        interaction: disnake.GuildCommandInteraction,
+        error_id: str = commands.Param(description="The error id"),
+    ):
+        """Retrieve information about a given error."""
+        error: Optional[Error] = await self.bot.db.error_tracking.find(
+            AQ(EQ("_id", error_id))
+        )
+        if not error:
+            return await interaction.send(
+                "No error exists with that ID.", ephemeral=True
+            )
+
+        embed = disnake.Embed(
+            colour=self.bot.colors.embed_color,
+            timestamp=self.bot.state.now,
+            title=f"Information for error {error.id}",
+            description=f"**Command name**: `{error.command_name}`\n\n"
+            f"**Shard ID**: `{error.shard_id}` | **Cluster ID**: `{error.cluster_id}`\n"
+            f"**User ID**: `{error.user_id}` | **Guild ID**: `{error.guild_id}`\n\n"
+            f"**Error**: `{error.error}`\n"
+            f"**Error occurred**: `{naturaldate(error.created_at)}` (`{error.created_at}`)",
+        )
+        await interaction.send(
+            embed=embed,
+            ephemeral=True,
+            file=disnake.File(io.StringIO(error.traceback), filename="traceback.txt"),
+        )
+
+    @error_information.autocomplete("error_id")
+    async def get_error_ids(
+        self,
+        interaction: disnake.ApplicationCommandInteraction,
+        user_input: str,
+    ):
+        values = list(self.bot.state.existing_error_ids)
+        possible_choices = [v for v in values if user_input.lower() in v.lower()]
+
+        if len(possible_choices) > 25:
+            return []
+
+        return possible_choices
 
 
 def setup(bot):

--- a/suggestions/database.py
+++ b/suggestions/database.py
@@ -1,7 +1,7 @@
 from alaric import Document
 from bot_base.db import MongoManager
 
-from suggestions.objects import Suggestion, GuildConfig, UserConfig
+from suggestions.objects import Suggestion, GuildConfig, UserConfig, Error
 from suggestions.objects.stats import MemberStats
 
 
@@ -29,3 +29,6 @@ class SuggestionsMongoManager(MongoManager):
             self.db, "member_stats", converter=MemberStats
         )
         self.locale_tracking: Document = Document(self.db, "locale_tracking")
+        self.error_tracking: Document = Document(
+            self.db, "error_tracking", converter=Error
+        )

--- a/suggestions/objects/__init__.py
+++ b/suggestions/objects/__init__.py
@@ -1,5 +1,6 @@
 from .user_config import UserConfig
 from .guild_config import GuildConfig
 from .suggestion import Suggestion
+from .error import Error
 
-__all__ = ("Suggestion", "GuildConfig", "UserConfig")
+__all__ = ("Suggestion", "GuildConfig", "UserConfig", "Error")

--- a/suggestions/objects/error.py
+++ b/suggestions/objects/error.py
@@ -24,6 +24,10 @@ class Error:
         self.command_name: str = command_name
         self.created_at: datetime.datetime = created_at
 
+    @property
+    def id(self) -> str:
+        return self._id
+
     def as_filter(self) -> dict:
         return {"_id": self._id}
 

--- a/suggestions/objects/error.py
+++ b/suggestions/objects/error.py
@@ -1,0 +1,41 @@
+import datetime
+
+
+class Error:
+    def __init__(
+        self,
+        _id: str,
+        traceback: str,
+        error: str,
+        user_id: int,
+        guild_id: int,
+        command_name: str,
+        cluster_id: int,
+        shard_id: int,
+        created_at: datetime.datetime,
+    ):
+        self._id: str = _id
+        self.error: str = error
+        self.user_id: int = user_id
+        self.guild_id: int = guild_id
+        self.shard_id: int = shard_id
+        self.traceback: str = traceback
+        self.cluster_id: int = cluster_id
+        self.command_name: str = command_name
+        self.created_at: datetime.datetime = created_at
+
+    def as_filter(self) -> dict:
+        return {"_id": self._id}
+
+    def as_dict(self) -> dict:
+        return {
+            "_id": self._id,
+            "error": self.error,
+            "user_id": self.user_id,
+            "guild_id": self.guild_id,
+            "shard_id": self.shard_id,
+            "traceback": self.traceback,
+            "cluster_id": self.cluster_id,
+            "command_name": self.command_name,
+            "created_at": self.created_at,
+        }


### PR DESCRIPTION
## Summary

Adds the ability to persist errors for help at later stages without the need to open the server logs to debug whats happened

Closes #27 

## Checklist


- [x] Has been manually tested
- [ ] Has unit-tests, if applicable
- [ ] New features have attached cooldowns
- [x] Any new strings are localized correctly
- [x] These work on both new and old style suggestions
- [ ] All interactions have been deferred 
