### PR TITLE
feat: add support for viewing suggestion voters via slash command

### DIFF
--- a/suggestions/locales/en_GB.json
+++ b/suggestions/locales/en_GB.json
@@ -104,5 +104,6 @@
   "CONFIG_GET_INNER_IMAGES_IN_SUGGESTIONS_NOT_SET": "cannot",
   "CONFIG_GET_INNER_IMAGES_IN_SUGGESTIONS_MESSAGE": "This guild {} have images in suggestions.",
   "CONFIG_SUGGESTIONS_IMAGES_ENABLE_INNER_MESSAGE": "All new suggestions can include images.",
-  "CONFIG_SUGGESTIONS_IMAGES_DISABLE_INNER_MESSAGE": "All new suggestions cannot include images."
+  "CONFIG_SUGGESTIONS_IMAGES_DISABLE_INNER_MESSAGE": "All new suggestions cannot include images.",
+  "VIEW_VOTERS_INNER_EMBED_TITLE": "Viewing voters"
 }


### PR DESCRIPTION
## Summary

Closes #35

## Checklist


- [x] Has been manually tested
- [ ] Has unit-tests, if applicable
- [x] New features have attached cooldowns
- [x] Any new strings are localized correctly
- [x] These work on both new and old style suggestions
- [x] All interactions have been deferred 
- [ ] New errors have been updated on ``stats.suggestions.gg``
- [ ] Guild config method names aren't duplicated
