### PR TITLE
Feature branch: Version 3.17

### DIFF
--- a/suggestions/bot.py
+++ b/suggestions/bot.py
@@ -45,7 +45,7 @@ log = logging.getLogger(__name__)
 
 class SuggestionsBot(commands.AutoShardedInteractionBot, BotBase):
     def __init__(self, *args, **kwargs):
-        self.version: str = "Public Release 3.16"
+        self.version: str = "Public Release 3.17"
         self.main_guild_id: int = 601219766258106399
         self.legacy_beta_role_id: int = 995588041991274547
         self.automated_beta_role_id: int = 998173237282361425

--- a/suggestions/cogs/suggestion_queue_cog.py
+++ b/suggestions/cogs/suggestion_queue_cog.py
@@ -126,7 +126,7 @@ class SuggestionsQueueCog(commands.Cog):
         except:
             # Throw it back in the queue on error
             current_suggestion.resolved_by = None
-            current_suggestion.resolved_at = self.bot.state.now
+            current_suggestion.resolved_at = None
             current_suggestion.still_in_queue = True
             await self.bot.state.queued_suggestions_db.update(
                 current_suggestion, current_suggestion

--- a/suggestions/objects/suggestion.py
+++ b/suggestions/objects/suggestion.py
@@ -882,6 +882,7 @@ class Suggestion:
                     ),
                 ],
             )
+            log.debug("Sent suggestion %s to channel", self.suggestion_id)
         except disnake.Forbidden as e:
             state.remove_sid_from_cache(interaction.guild_id, self.suggestion_id)
             await state.suggestions_db.delete(self.as_filter())


### PR DESCRIPTION
## Summary

Version 3.17 of the bot, changes:

- Adds logging to track down duplicate suggestion messages
- Fix queued suggestions being marked as resolved_at when they should be reset to `None`

## Checklist


- [x] Has been manually tested
- [ ] Has unit-tests, if applicable
- [ ] New features have attached cooldowns
- [ ] Any new strings are localized correctly
- [ ] These work on both new and old style suggestions
- [ ] All interactions have been deferred 
- [ ] New errors have been updated on ``stats.suggestions.gg``
- [ ] Guild config method names aren't duplicated
- [ ] New localizations have been added
- [ ] Documentation on ``docs.suggestions.gg`` has been updated