### PR TITLE
fix: viewing voters for cleared suggestions

### DIFF
--- a/suggestions/cogs/view_voters_cog.py
+++ b/suggestions/cogs/view_voters_cog.py
@@ -12,6 +12,7 @@ from bot_base.paginators.disnake_paginator import DisnakePaginator
 from suggestions import Colors
 from suggestions.cooldown_bucket import InteractionBucket
 from suggestions.objects import Suggestion
+from suggestions.objects.suggestion import SuggestionState
 
 if TYPE_CHECKING:
     from alaric import Document
@@ -109,6 +110,13 @@ class ViewVotersCog(commands.Cog):
             channel_id=interaction.channel_id,
             state=self.state,
         )
+        if suggestion.state == SuggestionState.cleared:
+            return await interaction.send(
+                self.bot.get_locale(
+                    "VIEW_VOTERS_CLEARED_SUGGESTION", interaction.locale
+                ),
+                ephemeral=True,
+            )
 
         up_vote: disnake.Emoji = await self.bot.suggestion_emojis.default_up_vote()
         down_vote: disnake.Emoji = await self.bot.suggestion_emojis.default_down_vote()
@@ -140,6 +148,14 @@ class ViewVotersCog(commands.Cog):
             channel_id=interaction.channel_id,
             state=self.state,
         )
+        if suggestion.state == SuggestionState.cleared:
+            return await interaction.send(
+                self.bot.get_locale(
+                    "VIEW_VOTERS_CLEARED_SUGGESTION", interaction.locale
+                ),
+                ephemeral=True,
+            )
+
         data = []
         for voter in suggestion.up_voted_by:
             data.append(f"<@{voter}>")
@@ -165,6 +181,14 @@ class ViewVotersCog(commands.Cog):
             channel_id=interaction.channel_id,
             state=self.state,
         )
+        if suggestion.state == SuggestionState.cleared:
+            return await interaction.send(
+                self.bot.get_locale(
+                    "VIEW_VOTERS_CLEARED_SUGGESTION", interaction.locale
+                ),
+                ephemeral=True,
+            )
+
         data = []
         for voter in suggestion.down_voted_by:
             data.append(f"<@{voter}>")
@@ -203,6 +227,14 @@ class ViewVotersCog(commands.Cog):
             guild_id=interaction.guild_id,
             state=self.state,
         )
+        if suggestion.state == SuggestionState.cleared:
+            return await interaction.send(
+                self.bot.get_locale(
+                    "VIEW_VOTERS_CLEARED_SUGGESTION", interaction.locale
+                ),
+                ephemeral=True,
+            )
+
         data = []
         up_vote: disnake.Emoji = await self.bot.suggestion_emojis.default_up_vote()
         down_vote: disnake.Emoji = await self.bot.suggestion_emojis.default_down_vote()

--- a/suggestions/locales/en_GB.json
+++ b/suggestions/locales/en_GB.json
@@ -121,5 +121,6 @@
   "SUGGESTION_ID_NAME": "suggestion_id",
   "SUGGESTION_ID_DESCRIPTION": "The suggestions ID you wish to reference.",
   "USER_ID_NAME": "user_id",
-  "USER_ID_DESCRIPTION": "The users discord id."
+  "USER_ID_DESCRIPTION": "The users discord id.",
+  "VIEW_VOTERS_CLEARED_SUGGESTION": "Cannot view a cleared suggestion."
 }

--- a/suggestions/state.py
+++ b/suggestions/state.py
@@ -12,6 +12,7 @@ import disnake
 from alaric import AQ
 from alaric.comparison import EQ
 from alaric.logical import AND
+from alaric.meta import Negate
 from alaric.projections import PROJECTION, SHOW
 from bot_base import NonExistentEntry
 from bot_base.caches import TimedCache
@@ -166,7 +167,7 @@ class State:
     async def populate_view_voters_cache(self, guild_id: int) -> list:
         self.view_voters_cache.delete_entry(guild_id)
         data: List[Dict] = await self.database.suggestions.find_many(
-            AQ(EQ("guild_id", guild_id)),
+            AQ(AND(EQ("guild_id", guild_id), Negate(EQ("state", "cleared")))),
             projections=PROJECTION(SHOW("_id")),
             try_convert=False,
         )


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? -->

## Checklist


- [x] Has been manually tested
- [ ] Has unit-tests, if applicable
- [x] New features have attached cooldowns
- [x] Any new strings are localized correctly
- [x] These work on both new and old style suggestions
- [ ] All interactions have been deferred 
- [ ] New errors have been updated on ``stats.suggestions.gg``
- [ ] Guild config method names aren't duplicated
- [x] New localizations have been added
- [ ] Documentation on ``docs.suggestions.gg`` has been updated