### PR TITLE
fix: queue approver disclosure

### DIFF
--- a/suggestions/objects/suggestion.py
+++ b/suggestions/objects/suggestion.py
@@ -925,11 +925,16 @@ class Suggestion:
                 log.debug("Created a thread on suggestion %s", self.suggestion_id)
 
         try:
+            suggestion_author = (
+                f"<@{self.suggestion_author_id}>"
+                if comes_from_queue
+                else interaction.author.mention
+            )
             embed: disnake.Embed = disnake.Embed(
                 description=bot.get_locale(
                     "SUGGEST_INNER_SUGGESTION_SENT", interaction.locale
                 ).format(
-                    interaction.author.mention,
+                    suggestion_author,
                     channel.mention,
                     self.suggestion_id,
                 ),


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? -->
This PR fixes the fact you can see who approved your suggestion from within the queue

## Checklist


- [ ] Has been manually tested
- [ ] Has unit-tests, if applicable
- [ ] New features have attached cooldowns
- [ ] Any new strings are localized correctly
- [ ] These work on both new and old style suggestions
- [ ] All interactions have been deferred 
- [ ] New errors have been updated on ``stats.suggestions.gg``
- [ ] Guild config method names aren't duplicated
- [ ] New localizations have been added
- [ ] Documentation on ``docs.suggestions.gg`` has been updated