### PR TITLE
Update the pt-BR translation

### DIFF
--- a/suggestions/locales/pt_BR.json
+++ b/suggestions/locales/pt_BR.json
@@ -57,6 +57,7 @@
   "SUGGEST_INNER_SENT_TO_QUEUE": "Sua sugestão foi enviada à fila para processamento.",
   "SUGGEST_INNER_NO_ANONYMOUS_SUGGESTIONS": "Seu servidor não permite sugestões anônimas.",
   "SUGGEST_INNER_NO_IMAGES_IN_SUGGESTIONS": "Seu servidor não permite imagens em sugestões.",
+  "SUGGEST_INNER_PING_AUTHOR_IN_THREAD": "Ei, <@$AUTHOR_ID>, criei este tópico para você discutir sua sugestão nele.",
   "CONFIG_ANONYMOUS_ENABLE_INNER_SUCCESS": "Habilitei sugestões anônimas para este servidor.",
   "CONFIG_ANONYMOUS_DISABLE_INNER_SUCCESS": "Desabilitei sugestões anônimas para este servidor.",
   "SUGGESTION_OBJECT_LOCK_THREAD": "Trancando este tópico já que a sugestão chegou a uma resolução.",


### PR DESCRIPTION
## Summary
Translates the bot's ping in new suggestion threads to Brazilian Portuguese (pt-BR).

## Checklist
- [ ] Has been manually tested
- [ ] Has unit tests, if applicable
- [ ] New features have attached cooldowns
- [x] Any new strings are localized correctly
- [ ] These work on both new and old-style suggestions
- [ ] All interactions have been deferred 
- [ ] New errors have been updated on ``stats.suggestions.gg``
- [x] Guild config method names aren't duplicated
- [ ] New localizations have been added
- [ ] Documentation on ``docs.suggestions.gg`` has been updated
- [x] Do these changes make sure not to expose anonymous suggestion authors?
- [x] Do these changes have the correct default discord permissions setup?
